### PR TITLE
'for' loop initial declarations are only allowed in C99 or C11 mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIBS = -lvita2d -lSceDisplay_stub -lSceGxm_stub -lSceCommonDialog_stub \
 
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
-CFLAGS  = -Wl,-q -Wall -O3
+CFLAGS  = -Wl,-q -Wall -O3 -std=c99
 ASFLAGS = $(CFLAGS)
 
 all: $(TARGET).vpk


### PR DESCRIPTION
the multitouch patch introduces new for loops that break in the default mode
forces gcc to use c99 to fix this issue